### PR TITLE
BTAT-11459 Upgraded hmrc-mongo and implemented TTL

### DIFF
--- a/app/common/Constants.scala
+++ b/app/common/Constants.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+object Constants {
+
+  val timeToLiveInSeconds = 2628000   // one month
+}

--- a/app/controllers/SecureMessageController.scala
+++ b/app/controllers/SecureMessageController.scala
@@ -17,7 +17,7 @@
 package controllers
 
 import models.SecureCommsRequestModel
-import models.SecureCommsServiceRequestModel.format
+import models.SecureCommsServiceRequestModel.formats
 import play.api.libs.json.JsValue
 import play.api.mvc._
 import services.SecureMessageService

--- a/app/models/DynamicDataModel.scala
+++ b/app/models/DynamicDataModel.scala
@@ -16,7 +16,9 @@
 
 package models
 
-import play.api.libs.json.{JsValue, Json, OFormat}
+import play.api.libs.json.{Format, JsNull, JsObject, JsValue, Json, Writes}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+import java.time.Instant
 
 case class DynamicDataModel(_id: String,
                             method: String,
@@ -24,5 +26,18 @@ case class DynamicDataModel(_id: String,
                             response: Option[JsValue])
 
 object DynamicDataModel {
-  implicit val formats: OFormat[DynamicDataModel] = Json.format[DynamicDataModel]
+  implicit val dateFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  implicit val formats: Format[DynamicDataModel] = Format(
+    Json.reads[DynamicDataModel],
+    Writes[DynamicDataModel] { model =>
+      JsObject(Json.obj(
+        "_id" -> model._id,
+        "method" -> model.method,
+        "status" -> model.status,
+        "response" -> model.response,
+        "creationTimestamp" -> Instant.now()
+      ).fields.filterNot(_._2 == JsNull))
+    }
+  )
 }

--- a/app/models/EmailRequestModel.scala
+++ b/app/models/EmailRequestModel.scala
@@ -16,7 +16,9 @@
 
 package models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Format, JsNull, JsObject, Json, Writes}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+import java.time.Instant
 
 case class EmailRequestModel(to: Seq[String],
                              templateId: String,
@@ -24,5 +26,18 @@ case class EmailRequestModel(to: Seq[String],
                              force: Boolean)
 
 object EmailRequestModel {
-  implicit val formats: OFormat[EmailRequestModel] = Json.format[EmailRequestModel]
+  implicit val dateFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  implicit val formats: Format[EmailRequestModel] = Format(
+    Json.reads[EmailRequestModel],
+    Writes[EmailRequestModel] { model =>
+      JsObject(Json.obj(
+        "to" -> model.to,
+        "templateId" -> model.templateId,
+        "parameters" -> model.parameters,
+        "force" -> model.force,
+        "creationTimestamp" -> Instant.now()
+      ).fields.filterNot(_._2 == JsNull))
+    }
+  )
 }

--- a/app/models/SecureCommsRequestModel.scala
+++ b/app/models/SecureCommsRequestModel.scala
@@ -16,7 +16,10 @@
 
 package models
 
-import play.api.libs.json.{Json, OFormat}
+import play.api.libs.json.{Format, JsNull, JsObject, Json, OFormat, Writes}
+import uk.gov.hmrc.mongo.play.json.formats.MongoJavatimeFormats
+
+import java.time.Instant
 
 case class TaxIdentifierModel(name: String, value: String)
 
@@ -54,5 +57,19 @@ case class SecureCommsRequestModel(externalRef: ExternalRefModel,
                                    content: String)
 
 object SecureCommsServiceRequestModel {
-  implicit val format: OFormat[SecureCommsRequestModel] = Json.format[SecureCommsRequestModel]
+  implicit val dateFormat: Format[Instant] = MongoJavatimeFormats.instantFormat
+
+  implicit val formats: Format[SecureCommsRequestModel] = Format(
+    Json.reads[SecureCommsRequestModel],
+    Writes[SecureCommsRequestModel] { model =>
+      JsObject(Json.obj(
+        "externalRef" -> model.externalRef,
+        "recipient" -> model.recipient,
+        "messageType" -> model.messageType,
+        "subject" -> model.subject,
+        "content" -> model.content,
+        "creationTimestamp" -> Instant.now()
+      ).fields.filterNot(_._2 == JsNull))
+    }
+  )
 }

--- a/app/repositories/DynamicStubRepository.scala
+++ b/app/repositories/DynamicStubRepository.scala
@@ -16,11 +16,14 @@
 
 package repositories
 
+import common.Constants
 import models.DynamicDataModel
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import play.api.libs.json.Format
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 
@@ -31,5 +34,9 @@ class DynamicStubRepository(mongo: MongoComponent)
   mongoComponent = mongo,
   collectionName = "data",
   domainFormat = formats,
-  indexes = Seq()
+  indexes = Seq(IndexModel(
+    Indexes.ascending("creationTimestamp"),
+    IndexOptions().name("expiry").expireAfter(Constants.timeToLiveInSeconds, TimeUnit.SECONDS)
+  )),
+  replaceIndexes = true
 )

--- a/app/repositories/EmailRepository.scala
+++ b/app/repositories/EmailRepository.scala
@@ -16,11 +16,14 @@
 
 package repositories
 
+import common.Constants
 import models.EmailRequestModel
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import play.api.libs.json.Format
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 
@@ -31,5 +34,9 @@ class EmailRepository(mongo: MongoComponent)
   mongoComponent = mongo,
   collectionName = "email",
   domainFormat = formats,
-  indexes = Seq()
+  indexes = Seq(IndexModel(
+    Indexes.ascending("creationTimestamp"),
+    IndexOptions().name("expiry").expireAfter(Constants.timeToLiveInSeconds, TimeUnit.SECONDS)
+  )),
+  replaceIndexes = true
 )

--- a/app/repositories/SecureMessageRepository.scala
+++ b/app/repositories/SecureMessageRepository.scala
@@ -16,11 +16,14 @@
 
 package repositories
 
+import common.Constants
 import models.SecureCommsRequestModel
+import org.mongodb.scala.model.{IndexModel, IndexOptions, Indexes}
 import play.api.libs.json.Format
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import uk.gov.hmrc.mongo.MongoComponent
 
+import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 import scala.concurrent.ExecutionContext
 
@@ -31,5 +34,9 @@ class SecureMessageRepository(mongo: MongoComponent)
   mongoComponent = mongo,
   collectionName = "secure-message",
   domainFormat = formats,
-  indexes = Seq()
+  indexes = Seq(IndexModel(
+    Indexes.ascending("creationTimestamp"),
+    IndexOptions().name("expiry").expireAfter(Constants.timeToLiveInSeconds, TimeUnit.SECONDS)
+  )),
+  replaceIndexes = true
 )

--- a/app/services/SecureMessageService.scala
+++ b/app/services/SecureMessageService.scala
@@ -17,7 +17,7 @@
 package services
 
 import models.SecureCommsRequestModel
-import models.SecureCommsServiceRequestModel.format
+import models.SecureCommsServiceRequestModel.formats
 import org.mongodb.scala.model.Filters.empty
 import org.mongodb.scala.result.{DeleteResult, InsertOneResult}
 import repositories.SecureMessageRepository

--- a/build.sbt
+++ b/build.sbt
@@ -16,21 +16,20 @@
 
 import sbt.Tests.{Group, SubProcess}
 import uk.gov.hmrc.DefaultBuildSettings.{addTestReportOption, defaultSettings, integrationTestSettings}
-import uk.gov.hmrc.sbtdistributables.SbtDistributablesPlugin.publishingSettings
 
 val appName = "digital-comms-dynamic-stub"
 
 lazy val appDependencies: Seq[ModuleID] = compile ++ test()
 
 val compile = Seq(
-  "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.14.0",
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "0.74.0"
+  "uk.gov.hmrc"       %% "bootstrap-backend-play-28" % "7.15.0",
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-play-28"        % "1.1.0"
 )
 
 def test(scope: String = "test, it"): Seq[ModuleID] = Seq(
-  "uk.gov.hmrc"       %% "bootstrap-test-play-28"      % "7.14.0"  % scope,
+  "uk.gov.hmrc"       %% "bootstrap-test-play-28"      % "7.15.0"  % scope,
   "org.scalamock"     %% "scalamock" % "5.2.0"         % scope,
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-28"     % "0.74.0" % scope
+  "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-28"     % "1.1.0" % scope
 )
 
 lazy val coverageSettings: Seq[Setting[_]] = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -19,12 +19,6 @@ include "backend.conf"
 
 appName=digital-comms-dynamic-stub
 
-# An ApplicationLoader that uses Guice to bootstrap the application.
-play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
-
-# Primary entry point for all HTTP requests on Play applications
-play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
-
 # Provides an implementation of AuditConnector. Use `uk.gov.hmrc.play.audit.AuditModule` or create your own.
 # An audit connector must be provided.
 play.modules.enabled += "uk.gov.hmrc.play.audit.AuditModule"

--- a/test/controllers/SecureMessageControllerSpec.scala
+++ b/test/controllers/SecureMessageControllerSpec.scala
@@ -18,7 +18,7 @@ package controllers
 
 import base.BaseSpec
 import mocks.MockSecureMessageService
-import models.SecureCommsServiceRequestModel.format
+import models.SecureCommsServiceRequestModel.formats
 import play.api.http.Status._
 import play.api.libs.json.Json
 import play.api.test.FakeRequest

--- a/test/repositories/DynamicStubRepositorySpec.scala
+++ b/test/repositories/DynamicStubRepositorySpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import base.BaseSpec
+import common.Constants
+import models.DynamicDataModel
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+class DynamicStubRepositorySpec extends BaseSpec with DefaultPlayMongoRepositorySupport[DynamicDataModel] {
+
+  override lazy val repository = new DynamicStubRepository(mongoComponent)
+
+  "The DynamicStubRepository" should {
+
+    "have a TTL index on the creationTimestamp field, with an expiry time set by the Constants object" in {
+      val indexes = {
+        await(repository.ensureIndexes())
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("expiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"creationTimestamp": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(Constants.timeToLiveInSeconds)
+    }
+  }
+}

--- a/test/repositories/EmailRepositorySpec.scala
+++ b/test/repositories/EmailRepositorySpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import base.BaseSpec
+import common.Constants
+import models.EmailRequestModel
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+class EmailRepositorySpec extends BaseSpec with DefaultPlayMongoRepositorySupport[EmailRequestModel] {
+
+  override lazy val repository = new EmailRepository(mongoComponent)
+
+  "The EmailRepository" should {
+
+    "have a TTL index on the creationTimestamp field, with an expiry time set by the Constants object" in {
+      val indexes = {
+        await(repository.ensureIndexes())
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("expiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"creationTimestamp": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(Constants.timeToLiveInSeconds)
+    }
+  }
+}

--- a/test/repositories/SecureMessageRepositorySpec.scala
+++ b/test/repositories/SecureMessageRepositorySpec.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package repositories
+
+import base.BaseSpec
+import common.Constants
+import models.SecureCommsRequestModel
+import models.SecureCommsServiceRequestModel.formats
+import org.mongodb.scala.bson.{BsonInt64, BsonString}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
+
+class SecureMessageRepositorySpec extends BaseSpec with DefaultPlayMongoRepositorySupport[SecureCommsRequestModel] {
+
+  override lazy val repository = new SecureMessageRepository(mongoComponent)
+
+  "The SecureMessageRepository" should {
+
+    "have a TTL index on the creationTimestamp field, with an expiry time set by the Constants object" in {
+      val indexes = {
+        await(repository.ensureIndexes())
+        await(repository.collection.listIndexes().toFuture())
+      }
+      val ttlIndex = indexes.find(_.get("name").contains(BsonString("expiry")))
+
+      ttlIndex.get("key").toString shouldBe """{"creationTimestamp": 1}"""
+      ttlIndex.get("expireAfterSeconds") shouldBe BsonInt64(Constants.timeToLiveInSeconds)
+    }
+  }
+}

--- a/test/services/SecureMessageServiceSpec.scala
+++ b/test/services/SecureMessageServiceSpec.scala
@@ -17,11 +17,11 @@
 package services
 
 import base.BaseSpec
-import models.SecureCommsServiceRequestModel.format
+import models.SecureCommsServiceRequestModel.formats
 import models._
 import repositories.SecureMessageRepository
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
-import uk.gov.hmrc.mongo.test.{DefaultPlayMongoRepositorySupport}
+import uk.gov.hmrc.mongo.test.DefaultPlayMongoRepositorySupport
 
 class SecureMessageServiceSpec extends BaseSpec with DefaultPlayMongoRepositorySupport[SecureCommsRequestModel] {
 


### PR DESCRIPTION
Example of the TTL index on one DB:
<img width="447" alt="image" src="https://user-images.githubusercontent.com/29063729/229474044-2fda18bf-0361-413a-9022-09e6aff16686.png">

Example of a document in one DB with the new date field:
<img width="569" alt="image" src="https://user-images.githubusercontent.com/29063729/229474197-f0f391f5-52ee-4919-9468-7369c5966577.png">
